### PR TITLE
Replace Binding<String?> by String? for read-only access

### DIFF
--- a/Sources/StatefulTabView/Helpers/Tab.swift
+++ b/Sources/StatefulTabView/Helpers/Tab.swift
@@ -13,14 +13,14 @@ public struct Tab {
     
     internal var prefersLargeTitle: Bool = false
     
-    @Binding var badgeValue: String?
+    let badgeValue: String?
     
     public init<T>(title: String,
                    imageName: String,
-                   badgeValue: Binding<String?> = .constant(nil),
+                   badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
         
-        _badgeValue = badgeValue
+        self.badgeValue = badgeValue
         barItem = UITabBarItem(title: title, image: UIImage(named: imageName), selectedImage: nil)
         
         self.view = AnyView(content())
@@ -28,10 +28,10 @@ public struct Tab {
     
     public init<T>(title: String,
                    systemImageName: String,
-                   badgeValue: Binding<String?> = .constant(nil),
+                   badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
         
-        _badgeValue = badgeValue
+        self.badgeValue = badgeValue
         barItem = UITabBarItem(title: title, image: UIImage(systemName: systemImageName), selectedImage: nil)
         
         self.view = AnyView(content())
@@ -39,10 +39,10 @@ public struct Tab {
     
     public init<T>(title: String,
                    image: UIImage?,
-                   badgeValue: Binding<String?> = .constant(nil),
+                   badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
         
-        _badgeValue = badgeValue
+        self.badgeValue = badgeValue
         barItem = UITabBarItem(title: title, image: image, selectedImage: nil)
         
         self.view = AnyView(content())


### PR DESCRIPTION
I'm super new to SwiftUI so I may have understood it wrong, anyway I found that opening a PR might be the fastest way to answer my question. This project still works for me after these changes - my badge still updates fine if I make it a `let` (immutable read-only) instead of passing in a Binding. https://swiftuipropertywrappers.com seems to suggest that approach when write access isn't needed.

Are there scenarios where Binding is needed here?

Thank you!

PS.: the practical reason why I didn't want to inject a Binding was that I wanted the badge to be computed from an @EnvironmentObject instead of having yet another property (probably a @State) that replicates part of that information.

```
struct AppView: View {
    @EnvironmentObject var myObject: MyObject

    var body: some View {
        StatefulTabView {
            Tab(title: "Foo", systemImageName: "0.circle", badgeValue: "\(myObject.items.count)") { // SwiftUI knows it needs to update this when myObject changes, if I had to inject a Binding how would I do it without creating a new property?
                MyView()
            }
        }
    }
}

class MyObject: ObservableObject {
  @Published var items = [MyItem]()
}
```