### PR TITLE
Unselected and Selected Tab initializers

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -60,7 +60,7 @@ struct ContentView: View {
             }
             .prefersLargeTitle(true)
             
-            Tab(title: "Tab 4", selectedSystemImageName: "shield.fill", unselectedSystemImageName: "shield") {
+            Tab(title: "Tab 4", systemImageName: "shield", selectedSystemImageName: "shield.fill") {
                 List {
                     Section {
                         ForEach(0..<20, id: \.self) { index in

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     
     var body: some View {
         StatefulTabView {
-            Tab(title: "Tab 1", systemImageName: "circle.fill", badgeValue: $badgeValue1) {
+            Tab(title: "Tab 1", systemImageName: "circle.fill", badgeValue: badgeValue1) {
                 NavigationView {
                     List {
                         Section {
@@ -60,7 +60,7 @@ struct ContentView: View {
             }
             .prefersLargeTitle(true)
             
-            Tab(title: "Tab 4", systemImageName: "shield.fill") {
+            Tab(title: "Tab 4", selectedSystemImageName: "shield.fill", unselectedSystemImageName: "shield") {
                 List {
                     Section {
                         ForEach(0..<20, id: \.self) { index in

--- a/Sources/StatefulTabView/Helpers/Tab.swift
+++ b/Sources/StatefulTabView/Helpers/Tab.swift
@@ -18,23 +18,18 @@ public struct Tab {
     // MARK: Asset Image Names
     public init<T>(title: String,
                    imageName: String,
+                   selectedImageName: String? = nil,
                    badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
         
         self.badgeValue = badgeValue
-        barItem = UITabBarItem(title: title, image: UIImage(named: imageName), selectedImage: nil)
         
-        self.view = AnyView(content())
-    }
-    
-    public init<T>(title: String,
-                   selectedImageName: String,
-                   unselectedImageName: String,
-                   badgeValue: String? = nil,
-                   @ViewBuilder content: @escaping () -> T) where T: View {
+        var selectedImage: UIImage?
+        if let selectedImageName = selectedImageName {
+            selectedImage = UIImage(named: selectedImageName)
+        }
         
-        self.badgeValue = badgeValue
-        barItem = UITabBarItem(title: title, image: UIImage(named: unselectedImageName), selectedImage: UIImage(named: selectedImageName))
+        barItem = UITabBarItem(title: title, image: UIImage(named: imageName), selectedImage: selectedImage)
         
         self.view = AnyView(content())
     }
@@ -42,23 +37,19 @@ public struct Tab {
     // MARK: System Image Names
     public init<T>(title: String,
                    systemImageName: String,
+                   selectedSystemImageName: String? = nil,
                    badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
         
         self.badgeValue = badgeValue
-        barItem = UITabBarItem(title: title, image: UIImage(systemName: systemImageName), selectedImage: nil)
         
-        self.view = AnyView(content())
-    }
-    
-    public init<T>(title: String,
-                   selectedSystemImageName: String,
-                   unselectedSystemImageName: String,
-                   badgeValue: String? = nil,
-                   @ViewBuilder content: @escaping () -> T) where T: View {
+        var selectedImage: UIImage?
+        if let selectedSystemImageName = selectedSystemImageName {
+            selectedImage = UIImage(systemName: selectedSystemImageName)
+        }
         
-        self.badgeValue = badgeValue
-        barItem = UITabBarItem(title: title, image: UIImage(systemName: unselectedSystemImageName), selectedImage: UIImage(systemName: selectedSystemImageName))
+        
+        barItem = UITabBarItem(title: title, image: UIImage(systemName: systemImageName), selectedImage: selectedImage)
         
         self.view = AnyView(content())
     }
@@ -66,25 +57,14 @@ public struct Tab {
     // MARK: UIImages
     public init<T>(title: String,
                    image: UIImage?,
+                   selectedImage: UIImage? = nil,
                    badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
         
         self.badgeValue = badgeValue
-        barItem = UITabBarItem(title: title, image: image, selectedImage: nil)
         
-        self.view = AnyView(content())
-    }
-    
-    public init<T>(title: String,
-                   image: UIImage?,
-                   selectedImage: UIImage?,
-                   badgeValue: String? = nil,
-                   @ViewBuilder content: @escaping () -> T) where T: View {
-        
-        self.badgeValue = badgeValue
         barItem = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
         
         self.view = AnyView(content())
     }
-
 }

--- a/Sources/StatefulTabView/Helpers/Tab.swift
+++ b/Sources/StatefulTabView/Helpers/Tab.swift
@@ -15,6 +15,7 @@ public struct Tab {
     
     let badgeValue: String?
     
+    // MARK: Asset Image Names
     public init<T>(title: String,
                    imageName: String,
                    badgeValue: String? = nil,
@@ -27,6 +28,19 @@ public struct Tab {
     }
     
     public init<T>(title: String,
+                   selectedImageName: String,
+                   unselectedImageName: String,
+                   badgeValue: String? = nil,
+                   @ViewBuilder content: @escaping () -> T) where T: View {
+        
+        self.badgeValue = badgeValue
+        barItem = UITabBarItem(title: title, image: UIImage(named: unselectedImageName), selectedImage: UIImage(named: selectedImageName))
+        
+        self.view = AnyView(content())
+    }
+    
+    // MARK: System Image Names
+    public init<T>(title: String,
                    systemImageName: String,
                    badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
@@ -38,6 +52,19 @@ public struct Tab {
     }
     
     public init<T>(title: String,
+                   selectedSystemImageName: String,
+                   unselectedSystemImageName: String,
+                   badgeValue: String? = nil,
+                   @ViewBuilder content: @escaping () -> T) where T: View {
+        
+        self.badgeValue = badgeValue
+        barItem = UITabBarItem(title: title, image: UIImage(systemName: unselectedSystemImageName), selectedImage: UIImage(systemName: selectedSystemImageName))
+        
+        self.view = AnyView(content())
+    }
+    
+    // MARK: UIImages
+    public init<T>(title: String,
                    image: UIImage?,
                    badgeValue: String? = nil,
                    @ViewBuilder content: @escaping () -> T) where T: View {
@@ -47,4 +74,17 @@ public struct Tab {
         
         self.view = AnyView(content())
     }
+    
+    public init<T>(title: String,
+                   image: UIImage?,
+                   selectedImage: UIImage?,
+                   badgeValue: String? = nil,
+                   @ViewBuilder content: @escaping () -> T) where T: View {
+        
+        self.badgeValue = badgeValue
+        barItem = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
+        
+        self.view = AnyView(content())
+    }
+
 }


### PR DESCRIPTION
- ~adds~ extends initializers for selected/unselected images 
- updates example project to run and show the shield tab as an example

@NicholasBellucci  ~not sure if you like how the new initializers are set up the way they are.~  I am more than happy to make an optional parameter or switch up to another mechanic you prefer.

Thanks for the lib! Super awesome 😄 