### PR TITLE
Add modifiers for tab bar item fonts and badges

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -77,6 +77,10 @@ struct ContentView: View {
         .unselectedItemTintColor(.green)
         .barBackgroundColor(.yellow)
         .barAppearanceConfiguration(.transparent)
+        .unselectedItemFont(UIFont(name: "AmericanTypewriter", size: 10)!)
+        .selectedItemFont(UIFont(name: "AvenirNext-HeavyItalic", size: 10)!)
+        .badgeFont(UIFont(name: "Courier-Bold", size: 22)!)
+        .badgeOffset(UIOffset(horizontal: -6, vertical: 12))
     }
 }
 

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -73,14 +73,26 @@ struct ContentView: View {
                 }
             }
         }
-        .barTintColor(.red)
-        .unselectedItemTintColor(.green)
-        .barBackgroundColor(.yellow)
-        .barAppearanceConfiguration(.transparent)
-        .unselectedItemFont(UIFont(name: "AmericanTypewriter", size: 10)!)
-        .selectedItemFont(UIFont(name: "AvenirNext-HeavyItalic", size: 10)!)
-        .badgeFont(UIFont(name: "Courier-Bold", size: 22)!)
-        .badgeOffset(UIOffset(horizontal: -6, vertical: 12))
+        .barBackgroundColor(.systemBackground)
+        .barAppearanceConfiguration(.opaque)
+        .selectedItemConfiguration(.init(
+            titleFont: UIFont(name: "AvenirNext-HeavyItalic", size: 10)!,
+            titleColor: .label,
+            iconColor: .label,
+            badgeFont: UIFont(name: "Courier-BoldOblique", size: 18)!,
+            badgeTextColor: .systemBackground,
+            badgeBackgroundColor: .label,
+            badgeOffset: .zero
+        ))
+        .unselectedItemConfiguration(.init(
+            titleFont: UIFont(name: "AmericanTypewriter", size: 10)!,
+            titleColor: .tertiaryLabel,
+            iconColor: .tertiaryLabel,
+            badgeFont: UIFont(name: "Courier", size: 18)!,
+            badgeTextColor: .systemBackground,
+            badgeBackgroundColor: .tertiaryLabel,
+            badgeOffset: .zero
+        ))
     }
 }
 

--- a/Sources/StatefulTabView/Helpers/TabBarController.swift
+++ b/Sources/StatefulTabView/Helpers/TabBarController.swift
@@ -13,17 +13,34 @@ public enum TabBarBackgroundConfiguration {
     case transparent
 }
 
+public struct TabBarItemConfiguration {
+    public var titleFont: UIFont
+    public var titleColor: UIColor
+    public var iconColor: UIColor
+    public var badgeFont: UIFont
+    public var badgeTextColor: UIColor
+    public var badgeBackgroundColor: UIColor
+    public var badgeOffset: UIOffset
+    
+    public init(titleFont: UIFont, titleColor: UIColor, iconColor: UIColor, badgeFont: UIFont, badgeTextColor: UIColor, badgeBackgroundColor: UIColor, badgeOffset: UIOffset? = .zero) {
+        self.titleFont = titleFont
+        self.titleColor = titleColor
+        self.iconColor = iconColor
+        self.badgeFont = badgeFont
+        self.badgeTextColor = badgeTextColor
+        self.badgeBackgroundColor = badgeBackgroundColor
+        self.badgeOffset = badgeOffset ?? .zero
+    }
+}
+
 struct TabBarController: UIViewControllerRepresentable {
     var controllers: [UIViewController]
     var tabBarItems: [Tab]
     
-    var barTintColor: UIColor?
-    var unselectedItemTintColor: UIColor?
     var backgroundColor: UIColor?
-    var unselectedItemFont: UIFont?
-    var selectedItemFont: UIFont?
-    var badgeFont: UIFont?
-    var badgeOffset: UIOffset?
+    var selectedItemConfiguration: TabBarItemConfiguration?
+    var unselectedItemConfiguration: TabBarItemConfiguration?
+    
     var tabBarConfiguration: TabBarBackgroundConfiguration?
     
     @Binding var selectedIndex: Int
@@ -69,56 +86,65 @@ private extension TabBarController {
                 appearance.configureWithTransparentBackground()
             }
         }
-
-        if let barTintColor = barTintColor {
-            tabBar.tintColor = barTintColor
-        }
-
-        // UITabBarItem font
-        if #available(iOS 13.0, *) {
-            var attrs: [NSAttributedString.Key: Any] = [:]
-            if let unselectedItemTintColor = unselectedItemTintColor { attrs[.foregroundColor] = unselectedItemTintColor }
-            if let unselectedItemFont = unselectedItemFont { attrs[.font] = unselectedItemFont }
-            if !attrs.isEmpty { appearance.stackedLayoutAppearance.normal.titleTextAttributes = attrs }
-            
-            attrs = [:]
-            if let selectedItemFont = selectedItemFont { attrs[.font] = selectedItemFont }
-            if !attrs.isEmpty { appearance.stackedLayoutAppearance.selected.titleTextAttributes = attrs }
-        }
-        
-        // Badge font
-        if let badgeFont = badgeFont {
-            if #available(iOS 13.0, *) {
-                appearance.stackedLayoutAppearance.normal.badgeTextAttributes = [.font: badgeFont]
-            }
-        }
-        
-        // Badge offset
-        if let badgeOffset = badgeOffset {
-            if #available(iOS 13.0, *) {
-                appearance.stackedLayoutAppearance.normal.badgePositionAdjustment = badgeOffset
-            }
-        }
-        
-        // Unselected item tint color + badge color
-        if let unselectedItemTintColor = unselectedItemTintColor {
-            if #available(iOS 13.0, *) {
-                appearance.stackedLayoutAppearance.normal.iconColor = unselectedItemTintColor
-                appearance.stackedLayoutAppearance.normal.badgeBackgroundColor = unselectedItemTintColor
-            } else {
-                tabBar.unselectedItemTintColor = unselectedItemTintColor
-            }
-        }
-        
-        // Selected item badge color
-        if let barTintColor = barTintColor {
-            if #available(iOS 13.0, *) {
-                appearance.stackedLayoutAppearance.selected.badgeBackgroundColor = barTintColor
-            }
-        }
         
         if let backgroundColor = backgroundColor {
             tabBar.backgroundColor = backgroundColor
+        }
+        
+        if let conf = unselectedItemConfiguration {
+            tabBar.tintColor = conf.titleColor
+            
+            if #available(iOS 13.0, *) {
+                appearance.stackedLayoutAppearance.normal.titleTextAttributes = [
+                    .font: conf.titleFont,
+                    .foregroundColor: conf.titleColor
+                ]
+                appearance.stackedLayoutAppearance.normal.badgeTextAttributes = [
+                    .font: conf.badgeFont,
+                    .foregroundColor: conf.badgeTextColor
+                ]
+                appearance.stackedLayoutAppearance.normal.iconColor = conf.iconColor
+                appearance.stackedLayoutAppearance.normal.badgeBackgroundColor = conf.badgeBackgroundColor
+                appearance.stackedLayoutAppearance.normal.badgePositionAdjustment = conf.badgeOffset
+                
+                appearance.inlineLayoutAppearance.normal.titleTextAttributes = appearance.stackedLayoutAppearance.normal.titleTextAttributes
+                appearance.inlineLayoutAppearance.normal.badgeTextAttributes = appearance.stackedLayoutAppearance.normal.badgeTextAttributes
+                appearance.inlineLayoutAppearance.normal.iconColor = appearance.stackedLayoutAppearance.normal.iconColor
+                appearance.inlineLayoutAppearance.normal.badgeBackgroundColor = appearance.stackedLayoutAppearance.normal.badgeBackgroundColor
+                
+                appearance.compactInlineLayoutAppearance.normal.titleTextAttributes = appearance.stackedLayoutAppearance.normal.titleTextAttributes
+                appearance.compactInlineLayoutAppearance.normal.badgeTextAttributes = appearance.stackedLayoutAppearance.normal.badgeTextAttributes
+                appearance.compactInlineLayoutAppearance.normal.iconColor = appearance.stackedLayoutAppearance.normal.iconColor
+                appearance.compactInlineLayoutAppearance.normal.badgeBackgroundColor = appearance.stackedLayoutAppearance.normal.badgeBackgroundColor
+            }
+        }
+        
+        if let conf = selectedItemConfiguration {
+            tabBar.tintColor = conf.titleColor
+            
+            if #available(iOS 13.0, *) {
+                appearance.stackedLayoutAppearance.selected.titleTextAttributes = [
+                    .font: conf.titleFont,
+                    .foregroundColor: conf.titleColor
+                ]
+                appearance.stackedLayoutAppearance.selected.badgeTextAttributes = [
+                    .font: conf.badgeFont,
+                    .foregroundColor: conf.badgeTextColor
+                ]
+                appearance.stackedLayoutAppearance.selected.iconColor = conf.iconColor
+                appearance.stackedLayoutAppearance.selected.badgeBackgroundColor = conf.badgeBackgroundColor
+                appearance.stackedLayoutAppearance.selected.badgePositionAdjustment = conf.badgeOffset
+                
+                appearance.inlineLayoutAppearance.selected.titleTextAttributes = appearance.stackedLayoutAppearance.selected.titleTextAttributes
+                appearance.inlineLayoutAppearance.selected.badgeTextAttributes = appearance.stackedLayoutAppearance.selected.badgeTextAttributes
+                appearance.inlineLayoutAppearance.selected.iconColor = appearance.stackedLayoutAppearance.selected.iconColor
+                appearance.inlineLayoutAppearance.selected.badgeBackgroundColor = appearance.stackedLayoutAppearance.selected.badgeBackgroundColor
+                
+                appearance.compactInlineLayoutAppearance.selected.titleTextAttributes = appearance.stackedLayoutAppearance.selected.titleTextAttributes
+                appearance.compactInlineLayoutAppearance.selected.badgeTextAttributes = appearance.stackedLayoutAppearance.selected.badgeTextAttributes
+                appearance.compactInlineLayoutAppearance.selected.iconColor = appearance.stackedLayoutAppearance.selected.iconColor
+                appearance.compactInlineLayoutAppearance.selected.badgeBackgroundColor = appearance.stackedLayoutAppearance.selected.badgeBackgroundColor
+            }
         }
         
         tabBar.standardAppearance = appearance

--- a/Sources/StatefulTabView/Helpers/TabBarController.swift
+++ b/Sources/StatefulTabView/Helpers/TabBarController.swift
@@ -20,6 +20,10 @@ struct TabBarController: UIViewControllerRepresentable {
     var barTintColor: UIColor?
     var unselectedItemTintColor: UIColor?
     var backgroundColor: UIColor?
+    var unselectedItemFont: UIFont?
+    var selectedItemFont: UIFont?
+    var badgeFont: UIFont?
+    var badgeOffset: UIOffset?
     var tabBarConfiguration: TabBarBackgroundConfiguration?
     
     @Binding var selectedIndex: Int
@@ -65,17 +69,51 @@ private extension TabBarController {
                 appearance.configureWithTransparentBackground()
             }
         }
-        
+
         if let barTintColor = barTintColor {
             tabBar.tintColor = barTintColor
         }
 
+        // UITabBarItem font
+        if #available(iOS 13.0, *) {
+            var attrs: [NSAttributedString.Key: Any] = [:]
+            if let unselectedItemTintColor = unselectedItemTintColor { attrs[.foregroundColor] = unselectedItemTintColor }
+            if let unselectedItemFont = unselectedItemFont { attrs[.font] = unselectedItemFont }
+            if !attrs.isEmpty { appearance.stackedLayoutAppearance.normal.titleTextAttributes = attrs }
+            
+            attrs = [:]
+            if let selectedItemFont = selectedItemFont { attrs[.font] = selectedItemFont }
+            if !attrs.isEmpty { appearance.stackedLayoutAppearance.selected.titleTextAttributes = attrs }
+        }
+        
+        // Badge font
+        if let badgeFont = badgeFont {
+            if #available(iOS 13.0, *) {
+                appearance.stackedLayoutAppearance.normal.badgeTextAttributes = [.font: badgeFont]
+            }
+        }
+        
+        // Badge offset
+        if let badgeOffset = badgeOffset {
+            if #available(iOS 13.0, *) {
+                appearance.stackedLayoutAppearance.normal.badgePositionAdjustment = badgeOffset
+            }
+        }
+        
+        // Unselected item tint color + badge color
         if let unselectedItemTintColor = unselectedItemTintColor {
             if #available(iOS 13.0, *) {
-                appearance.stackedLayoutAppearance.normal.titleTextAttributes = [NSAttributedString.Key.foregroundColor: unselectedItemTintColor]
                 appearance.stackedLayoutAppearance.normal.iconColor = unselectedItemTintColor
+                appearance.stackedLayoutAppearance.normal.badgeBackgroundColor = unselectedItemTintColor
             } else {
                 tabBar.unselectedItemTintColor = unselectedItemTintColor
+            }
+        }
+        
+        // Selected item badge color
+        if let barTintColor = barTintColor {
+            if #available(iOS 13.0, *) {
+                appearance.stackedLayoutAppearance.selected.badgeBackgroundColor = barTintColor
             }
         }
         

--- a/Sources/StatefulTabView/Modifiers/StatefulTabView+Modifiers.swift
+++ b/Sources/StatefulTabView/Modifiers/StatefulTabView+Modifiers.swift
@@ -31,4 +31,28 @@ public extension StatefulTabView {
         copy.tabBarConfiguration = configuration
         return copy
     }
+    
+    func unselectedItemFont(_ font: UIFont?) -> StatefulTabView {
+        var copy = self
+        copy.unselectedItemFont = font
+        return copy
+    }
+    
+    func selectedItemFont(_ font: UIFont?) -> StatefulTabView {
+        var copy = self
+        copy.selectedItemFont = font
+        return copy
+    }
+    
+    func badgeFont(_ font: UIFont?) -> StatefulTabView {
+        var copy = self
+        copy.badgeFont = font
+        return copy
+    }
+    
+    func badgeOffset(_ offset: UIOffset) -> StatefulTabView {
+        var copy = self
+        copy.badgeOffset = offset
+        return copy
+    }
 }

--- a/Sources/StatefulTabView/Modifiers/StatefulTabView+Modifiers.swift
+++ b/Sources/StatefulTabView/Modifiers/StatefulTabView+Modifiers.swift
@@ -8,51 +8,27 @@
 import SwiftUI
 
 public extension StatefulTabView {
-    func barTintColor(_ color: UIColor) -> StatefulTabView {
-        var copy = self
-        copy.barTintColor = color
-        return copy
-    }
-
-    func unselectedItemTintColor(_ color: UIColor) -> StatefulTabView {
-        var copy = self
-        copy.unselectedItemTintColor = color
-        return copy
-    }
-    
     func barBackgroundColor(_ color: UIColor) -> StatefulTabView {
         var copy = self
         copy.backgroundColor = color
         return copy
     }
     
+    func selectedItemConfiguration(_ configuration: TabBarItemConfiguration) -> StatefulTabView {
+        var copy = self
+        copy.selectedItemConfiguration = configuration
+        return copy
+    }
+    
+    func unselectedItemConfiguration(_ configuration: TabBarItemConfiguration) -> StatefulTabView {
+        var copy = self
+        copy.unselectedItemConfiguration = configuration
+        return copy
+    }
+    
     func barAppearanceConfiguration(_ configuration: TabBarBackgroundConfiguration) -> StatefulTabView {
         var copy = self
         copy.tabBarConfiguration = configuration
-        return copy
-    }
-    
-    func unselectedItemFont(_ font: UIFont?) -> StatefulTabView {
-        var copy = self
-        copy.unselectedItemFont = font
-        return copy
-    }
-    
-    func selectedItemFont(_ font: UIFont?) -> StatefulTabView {
-        var copy = self
-        copy.selectedItemFont = font
-        return copy
-    }
-    
-    func badgeFont(_ font: UIFont?) -> StatefulTabView {
-        var copy = self
-        copy.badgeFont = font
-        return copy
-    }
-    
-    func badgeOffset(_ offset: UIOffset) -> StatefulTabView {
-        var copy = self
-        copy.badgeOffset = offset
         return copy
     }
 }

--- a/Sources/StatefulTabView/StatefulTabView.swift
+++ b/Sources/StatefulTabView/StatefulTabView.swift
@@ -15,6 +15,10 @@ public struct StatefulTabView: View {
     internal var unselectedItemTintColor: UIColor? = nil
     internal var backgroundColor: UIColor? = nil
     internal var tabBarConfiguration: TabBarBackgroundConfiguration? = nil
+    internal var unselectedItemFont: UIFont?
+    internal var selectedItemFont: UIFont?
+    internal var badgeFont: UIFont?
+    internal var badgeOffset: UIOffset?
     
     @State private var stateIndex: Int = 0
     @Binding private var bindableIndex: Int
@@ -39,6 +43,10 @@ public struct StatefulTabView: View {
                          barTintColor: barTintColor,
                          unselectedItemTintColor: unselectedItemTintColor,
                          backgroundColor: backgroundColor,
+                         unselectedItemFont: unselectedItemFont,
+                         selectedItemFont: selectedItemFont,
+                         badgeFont: badgeFont,
+                         badgeOffset: badgeOffset,
                          tabBarConfiguration: tabBarConfiguration,
                          selectedIndex: useBindableIndex ? $bindableIndex : $stateIndex)
             .edgesIgnoringSafeArea(.all)

--- a/Sources/StatefulTabView/StatefulTabView.swift
+++ b/Sources/StatefulTabView/StatefulTabView.swift
@@ -11,14 +11,11 @@ public struct StatefulTabView: View {
     internal var viewControllers: [UIHostingController<AnyView>] = []
     internal var tabBarItems: [Tab] = []
 
-    internal var barTintColor: UIColor? = nil
-    internal var unselectedItemTintColor: UIColor? = nil
     internal var backgroundColor: UIColor? = nil
+    internal var selectedItemConfiguration: TabBarItemConfiguration? = nil
+    internal var unselectedItemConfiguration: TabBarItemConfiguration? = nil
     internal var tabBarConfiguration: TabBarBackgroundConfiguration? = nil
-    internal var unselectedItemFont: UIFont?
-    internal var selectedItemFont: UIFont?
-    internal var badgeFont: UIFont?
-    internal var badgeOffset: UIOffset?
+
     
     @State private var stateIndex: Int = 0
     @Binding private var bindableIndex: Int
@@ -40,13 +37,9 @@ public struct StatefulTabView: View {
     public var body: some View {
         TabBarController(controllers: viewControllers,
                          tabBarItems: tabBarItems,
-                         barTintColor: barTintColor,
-                         unselectedItemTintColor: unselectedItemTintColor,
                          backgroundColor: backgroundColor,
-                         unselectedItemFont: unselectedItemFont,
-                         selectedItemFont: selectedItemFont,
-                         badgeFont: badgeFont,
-                         badgeOffset: badgeOffset,
+                         selectedItemConfiguration: selectedItemConfiguration,
+                         unselectedItemConfiguration: unselectedItemConfiguration,
                          tabBarConfiguration: tabBarConfiguration,
                          selectedIndex: useBindableIndex ? $bindableIndex : $stateIndex)
             .edgesIgnoringSafeArea(.all)


### PR DESCRIPTION
This PR introduces four new modifiers to StatefulTabView:
- `unselectedItemFont` and `selectedItemFont` changes the fonts used on tab bar items.
- `badgeFont` changes the font used on tab bar item badges.
- `badgeOffset` allows offsetting the badges

All of them only work on iOS 13+ as they use the `stackedLayoutAppearance`.

Also, for business requirements, the background color of the badges now follow selected/unselected tint color (TabBarController.swift lines 107 and 113-118). This can be removed if you don't feel like merging this feature.