### PR TITLE
Replace '_functionBuilder' with 'resultBuilder'

### DIFF
--- a/Sources/StatefulTabView/StatefulTabView.swift
+++ b/Sources/StatefulTabView/StatefulTabView.swift
@@ -56,7 +56,7 @@ private extension StatefulTabView {
     }
 }
 
-@_functionBuilder
+@resultBuilder
 public struct TabBuilder {
     public static func buildBlock(_ children: Tab...) -> [Tab] {
         children


### PR DESCRIPTION
Fix: '@_functionBuilder' has been renamed to '@resultBuilder'