### PR TITLE
Return early if the scroll view was found

### DIFF
--- a/Sources/StatefulTabView/Helpers/TabBarCoordinator.swift
+++ b/Sources/StatefulTabView/Helpers/TabBarCoordinator.swift
@@ -88,6 +88,10 @@ private extension TabBarCoordinator {
         var view: UIScrollView?
         
         views.forEach {
+            guard view == nil else {
+                return
+            }
+
             if let scrollView = $0 as? UIScrollView {
                 view = scrollView
             } else {


### PR DESCRIPTION
I recently came across an issue that if there were views to be processed after the scroll view was found it would end up being replaced with a `nil`. This change short circuits when finding the first scroll view.